### PR TITLE
Add support for Inline Prefixes

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -16,37 +16,40 @@ func main() {
 	defer func() {
 		err := recover()
 		if err != nil {
+			// Fatal message
 			log.WithFields(logrus.Fields{
-				"prefix": "main",
 				"omg":    true,
 				"number": 100,
-			}).Fatal("The ice breaks!")
+			}).Fatal("[main] The ice breaks!")
 		}
 	}()
 
+	// You could either provide a map key called `prefix` to add prefix
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 		"animal": "walrus",
 		"number": 8,
 	}).Debug("Started observing beach")
 
+	// Or you can simply add prefix in square brackets within message itself
 	log.WithFields(logrus.Fields{
-		"prefix": "main",
 		"animal": "walrus",
 		"size":   10,
-	}).Info("A group of walrus emerges from the ocean")
+	}).Debug("[main] A group of walrus emerges from the ocean")
 
+	// Warning message
 	log.WithFields(logrus.Fields{
-		"prefix": "main",
 		"omg":    true,
 		"number": 122,
-	}).Warn("The group's number increased tremendously!")
+	}).Warn("[main] The group's number increased tremendously!")
 
+	// Information message
 	log.WithFields(logrus.Fields{
 		"prefix":      "sensor",
 		"temperature": -4,
-	}).Debug("Temperature changes")
+	}).Info("Temperature changes")
 
+	// Panic message
 	log.WithFields(logrus.Fields{
 		"prefix": "sensor",
 		"animal": "orca",


### PR DESCRIPTION
In the current implementation, formatter requires you to provide an additional `prefix` field. Its okay if I'm already logging a few fields. But in other case, where I don't have any field to log, it becomes pain in the ass.

So, with this PR, you could add inline prefixes in the log messages for example:
```go
// without fields
log.Debug("[main] A group of walrus emerges from the ocean")
// with fields
log.WithFields(logrus.Fields{
		"animal": "walrus",
		"size":   10,
	}).Debug("[main] A group of walrus emerges from the ocean")
```
Note that, it doesn't break the old functionality. Moreover, `prefix` field method has more precedence. For example if you have inline logging and you add `prefix` field as well, like:
```go
log.WithFields(logrus.Fields{
		"animal": "walrus",
		"size":   10,
                "prefix": "foo"
	}).Debug("[bar] A group of walrus emerges from the ocean")
```
Then it would add the `foo` prefix and log the message as is: `[bar] A group of walrus emerges from the ocean` 