### PR TITLE
Add an option to add space padding for message when creating formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ func main() {
 * `TimestampFormat string` — timestamp format to use for display when a full timestamp is printed.
 * `DisableSorting bool` — the fields are sorted by default for a consistent output. For applications
 that log extremely frequently and don't use the JSON formatter this may not be desired.
+* `SpacePadding int` - Pad msg field with spaces on the right for display. 
+The value for this parameter will be the size of padding. Its default value is zero, which means no padding will be applied.
 
 # License
 MIT

--- a/formatter.go
+++ b/formatter.go
@@ -50,6 +50,11 @@ type TextFormatter struct {
 	// that log extremely frequently and don't use the JSON formatter this may not
 	// be desired.
 	DisableSorting bool
+
+	// Pad msg field with spaces on the right for display.
+	// The value for this parameter will be the size of padding.
+	// Its default value is zero, which means no padding will be applied for msg.
+	SpacePadding int
 }
 
 func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -127,10 +132,15 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		}
 	}
 
+	messageFormat := "%s"
+	if f.SpacePadding != 0 {
+		messageFormat = fmt.Sprintf("%%-%ds", f.SpacePadding)
+	}
+
 	if f.ShortTimestamp {
-		fmt.Fprintf(b, "%s[%04d]%s %s%+5s%s%s %s", ansi.LightBlack, miniTS(), reset, levelColor, levelText, reset, prefix, message)
+		fmt.Fprintf(b, "%s[%04d]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, miniTS(), reset, levelColor, levelText, reset, prefix, message)
 	} else {
-		fmt.Fprintf(b, "%s[%s]%s %s%+5s%s%s %s", ansi.LightBlack, entry.Time.Format(timestampFormat), reset, levelColor, levelText, reset, prefix, message)
+		fmt.Fprintf(b, "%s[%s]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, entry.Time.Format(timestampFormat), reset, levelColor, levelText, reset, prefix, message)
 	}
 	for _, k := range keys {
 		v := entry.Data[k]


### PR DESCRIPTION
In logrus's built-in TextFormatter, it formats the `msg` with right space padding (https://github.com/Sirupsen/logrus/blob/69df0d2ed71e288309a424ac82040635d7e29731/text_formatter.go#L119), which makes it easier to tell apart the logged event name (the `msg`) and the attributes associated with the event.

In this PR, I added one more exposed field called "SpacePadding" for TextFormatter, so that users can provide a value like "44" to achieve the same result as logrus's built-in TextFormatter.
```
[2016-11-02T15:08:45.302+08:00] DEBUG Service is initializing                  eventCount=10 name=apiserver
[2016-11-02T15:08:45.302+08:00]  INFO Service is starting up                   name=zombie server size=20
```