### PR TITLE
Make formatter compatible with logrus >= 0.11.1

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -17,12 +17,10 @@ const reset = ansi.Reset
 
 var (
 	baseTimestamp time.Time
-	isTerminal    bool
 )
 
 func init() {
 	baseTimestamp = time.Now()
-	isTerminal = logrus.IsTerminal()
 }
 
 func miniTS() int {
@@ -55,6 +53,10 @@ type TextFormatter struct {
 	// The value for this parameter will be the size of padding.
 	// Its default value is zero, which means no padding will be applied for msg.
 	SpacePadding int
+
+	// Whether the logger's out is to a terminal
+	isTerminal   bool
+	terminalOnce sync.Once
 }
 
 func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -73,8 +75,13 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	prefixFieldClashes(entry.Data)
 
-	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
-	isColored := (f.ForceColors || isColorTerminal) && !f.DisableColors
+	f.terminalOnce.Do(func() {
+		if entry.Logger != nil {
+			f.isTerminal = logrus.IsTerminal(entry.Logger.Out)
+		}
+	})
+
+	isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {


### PR DESCRIPTION
- logrus made a breaking API change to `IsTerminal` function in
  https://github.com/sirupsen/logrus/pull/471/files that result in
  compilation error.
- this commit pretty much cherry-picks changes to `TextFormatter` from
  https://github.com/sirupsen/logrus/pull/471/files#diff-291b40d95620791b320dc56694c3a111