### PR TITLE
Optionally disable the uppercasing of log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ func main() {
 
 * `ForceColors bool` — set to true to bypass checking for a TTY before outputting colors.
 * `DisableColors bool` — force disabling colors. For a TTY colors are enabled by default.
+* `DisableUppercase bool` — set to true to turn off the conversion of the log level names to uppercase.
 * `ForceFormatting bool` — force formatted layout, even for non-TTY output.
 * `DisableTimestamp bool` — disable timestamp logging. Useful when output is redirected to logging system that already adds timestamps.
 * `FullTimestamp bool` — enable logging the full timestamp when a TTY is attached instead of just the time passed since beginning of execution.

--- a/formatter.go
+++ b/formatter.go
@@ -78,6 +78,9 @@ type TextFormatter struct {
 	// system that already adds timestamps.
 	DisableTimestamp bool
 
+	// Disable the conversion of the log levels to uppercase
+	DisableUppercase bool
+
 	// Enable logging the full timestamp when a TTY is attached instead of just
 	// the time passed since beginning of execution.
 	FullTimestamp bool
@@ -222,9 +225,13 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	if entry.Level != logrus.WarnLevel {
-		levelText = strings.ToUpper(entry.Level.String())
+		levelText = entry.Level.String()
 	} else {
-		levelText = "WARN"
+		levelText = "warn"
+	}
+
+	if !f.DisableUppercase {
+		levelText = strings.ToUpper(levelText)
 	}
 
 	level := levelColor(fmt.Sprintf("%5s", levelText))


### PR DESCRIPTION
With colors enabled, the capitalized log levels are a bit aggressive.  The DisableUppercase option optionally disables this.