### PR TITLE
Fix double space in log line with empty message

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/mgutz/ansi"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -269,7 +269,11 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	if f.DisableTimestamp {
-		fmt.Fprintf(b, "%s%s "+messageFormat, level, prefix, message)
+		if message == "" {
+			fmt.Fprintf(b, "%s%s", level, prefix)
+		} else {
+			fmt.Fprintf(b, "%s%s "+messageFormat, level, prefix, message)
+		}
 	} else {
 		var timestamp string
 		if !f.FullTimestamp {
@@ -277,8 +281,16 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		} else {
 			timestamp = fmt.Sprintf("[%s]", entry.Time.Format(timestampFormat))
 		}
-		fmt.Fprintf(b, "%s %s%s "+messageFormat, colorScheme.TimestampColor(timestamp), level, prefix, message)
+
+		coloredTimestamp := colorScheme.TimestampColor(timestamp)
+
+		if message == "" {
+			fmt.Fprintf(b, "%s %s%s", coloredTimestamp, level, prefix)
+		} else {
+			fmt.Fprintf(b, "%s %s%s "+messageFormat, coloredTimestamp, level, prefix, message)
+		}
 	}
+
 	for _, k := range keys {
 		if k != "prefix" {
 			v := entry.Data[k]

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -3,9 +3,9 @@ package prefixed_test
 import (
 	. "github.com/x-cray/logrus-prefixed-formatter"
 
-	"github.com/sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Formatter", func() {
@@ -31,7 +31,7 @@ var _ = Describe("Formatter", func() {
 
 		It("should output message with additional field", func() {
 			formatter.DisableTimestamp = true
-			log.WithFields(logrus.Fields{ "animal": "walrus" }).Debug("test")
+			log.WithFields(logrus.Fields{"animal": "walrus"}).Debug("test")
 			Ω(output.GetValue()).Should(Equal("level=debug msg=test animal=walrus\n"))
 		})
 	})
@@ -42,6 +42,15 @@ var _ = Describe("Formatter", func() {
 			formatter.ForceFormatting = true
 			log.Debug("test")
 			Ω(output.GetValue()).Should(Equal("DEBUG test\n"))
+		})
+	})
+
+	Describe("Formatted output with no message", func() {
+		It("should not have two consecutive spaces", func() {
+			formatter.DisableTimestamp = true
+			formatter.ForceFormatting = true
+			log.WithFields(logrus.Fields{"animal": "walrus"}).Debug()
+			Ω(output.GetValue()).Should(Equal("DEBUG animal=walrus\n"))
 		})
 	})
 


### PR DESCRIPTION
When message was empty, terminal-formatted output will include an extra space e.g. 

```
INFO  foo=bar
```

This changes the formatting to e.g.

```
INFO foo=bar
```